### PR TITLE
fix: shasum/stat 跨平台回退（BSD/GNU 兼容）

### DIFF
--- a/sofagent/scripts/task-orchestrate.sh
+++ b/sofagent/scripts/task-orchestrate.sh
@@ -164,7 +164,8 @@ echo ""
 bash "${SCRIPT_DIR}/audit.sh" --operation "orchestrate" --target "${TASK_DESC}" --result "开始, L${LEVEL}" 2>/dev/null || true
 
 # ── 生成任务唯一标识 ──
-TASK_SLUG=$(echo "$TASK_DESC" | shasum -a 256 2>/dev/null | cut -c1-8 || echo "unknown")
+# shasum 缺失时回退 sha256sum（Alpine/精简 Linux 无 shasum，否则 TASK_SLUG 恒为 unknown）
+TASK_SLUG=$(echo "$TASK_DESC" | { shasum -a 256 2>/dev/null || sha256sum 2>/dev/null; } | cut -c1-8 || echo "unknown")
 
 # ── 读取 orchestrator/ 配置（如果存在）──
 SOFAGENT_DATA="${PWD}/.sofagent"

--- a/sofagent/scripts/verify.sh
+++ b/sofagent/scripts/verify.sh
@@ -615,7 +615,8 @@ fi
 # 9.3 反思更新频率
 [ "$JSON_MODE" = false ] && echo -n "  反思更新频率: "
 if [ -f ".sofagent/think.md" ]; then
-  modified_sec=$(($(date +%s) - $(stat -f %m ".sofagent/think.md" 2>/dev/null || echo 0)))
+  # GNU stat (-c %Y) 优先，BSD/macOS (-f %m) 回退；原 BSD-only 写法在 Linux 上恒返回 0 → 永远报"超旧"
+  modified_sec=$(($(date +%s) - $(stat -c %Y ".sofagent/think.md" 2>/dev/null || stat -f %m ".sofagent/think.md" 2>/dev/null || echo 0)))
   modified_days=$((modified_sec / 86400))
   if [ "$modified_days" -le 3 ]; then
     check_pass "think.md ${modified_days} 天前更新（活跃）"


### PR DESCRIPTION
task-orchestrate.sh: TASK_SLUG 在缺 shasum 的精简 Linux（Alpine）上回退
  sha256sum，否则哈希失败、TASK_SLUG 恒为 "unknown"。
verify.sh: think.md 修改时间改 GNU `stat -c %Y` 优先 + BSD `stat -f %m` 回退；
  原 BSD-only 写法在 Linux 上 stat 失败返回 0，反思频率永远误报"超旧"。

# Pull Request

> 请确认以下检查项全部通过后再合并。

## 自检清单

- [ ] **文档同步**：相关手册（`HANDBOOK.md` / `DEVELOPMENT.md` / `ARCHITECTURE.md`）已更新，交叉引用一致
- [ ] **验证通过**：`bash sofagent/scripts/verify.sh` 全部通过，无语法错误
- [ ] **部署循环**：跑过一次完整的安装→卸载→重装流程（`install.sh` + `uninstall.sh`）

### 脚本 / Skill 改动额外检查（纯文档改动可跳过）

> 仅当本 PR 修改了 `sofagent/scripts/` 或 `sofagent/*.md` 时勾选

- [ ] **非 OpenClaw 平台测试**：在至少一个非 OpenClaw 平台（Claude Code / WorkBuddy / Codex）验证过行为
- [ ] **参数兑现检查**：文档中描述的脚本参数（`--help` 输出）在代码中真实存在，没有虚构参数
- [ ] **脱敏回归**：如修改了 `sanitize()`，跑过 `verify.sh` 脱敏测试用例全部通过

## 变更说明

<!-- 简述此 PR 做了什么、为什么这样做 -->

## 影响范围

<!-- 标记受影响的模块： -->
- [ ] 宪法 / 规则层（rules.md、SKILL.md）
- [ ] 脚本层（scripts/）
- [ ] Skill / Hook 层
- [ ] 数据文件模板（.sofagent/）
- [ ] 文档 / 手册
- [ ] CI / 基础设施
